### PR TITLE
Use utime.time_ns() instead of ticks_us()

### DIFF
--- a/flow_hall/flow_hall_main.py
+++ b/flow_hall/flow_hall_main.py
@@ -177,7 +177,8 @@ class PicoFlowHall:
     def pulse_callback(self, pin):
         '''Compute the relative timestamp and add it to a list'''
         if not self.actively_publishing:
-            current_timestamp_us = utime.ticks_us()
+            #current_timestamp_us = utime.ticks_us()
+            current_timestamp_us = utime.time_ns() // 1000
             # Initialize the timestamp if this is the first pulse
             if self.first_tick_us is None:
                 self.first_tick_us = current_timestamp_us


### PR DESCRIPTION
Let's get to the bottom of this. Here is one try

From Thomas: _When publishing relative ticklists sometimes several ticks come very rapidly together at the beginning of a new ticklist. This creates sharp rises in frequency (which I can of course post process). Here's an example in the screenshot. I'm not sure why this is not happening with absolute timestamps, maybe because we don't have to go through the "if first_tick_us is None" part in the callback function? Anyways, when I process out these sections it looks like relative ticklists are working fine._

![bunched ticks](https://github.com/user-attachments/assets/a13fdb78-fb2d-4c64-a36f-9484b353c170)


